### PR TITLE
✨ swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'com.jcraft:jsch:0.1.55'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'mysql:mysql-connector-java:8.0.15'

--- a/src/main/java/io/oopy/coding/common/config/SwaggerConfig.java
+++ b/src/main/java/io/oopy/coding/common/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package io.oopy.coding.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new io.swagger.v3.oas.models.info.Info()
+                .title("80000 Coding API")
+                .description("80000 Coding API Docs")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/io/oopy/coding/common/security/SecurityConfig.java
+++ b/src/main/java/io/oopy/coding/common/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @Configuration
 @EnableWebSecurity
@@ -17,7 +18,8 @@ public class SecurityConfig {
             "/",
             "/favicon.ico",
             "/api-docs/**",
-            "/test/**"
+            "/test/**",
+            "/v3/api-docs/**", "/swagger-ui/**", "/swagger"
     };
 
     @Bean

--- a/src/main/java/io/oopy/coding/domain/entity/User.java
+++ b/src/main/java/io/oopy/coding/domain/entity/User.java
@@ -17,6 +17,9 @@ public class User extends Auditable{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "github_id", nullable = false)
+    private Integer githubId;
+
     @Column(name = "name", nullable = false)
     private String name;
 

--- a/src/main/java/io/oopy/coding/presentation/Test.java
+++ b/src/main/java/io/oopy/coding/presentation/Test.java
@@ -1,13 +1,19 @@
 package io.oopy.coding.presentation;
 
 import io.oopy.coding.service.TestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 
-@Controller
+@Tag(name = "테스트", description = "테스트용 API")
+@RestController
+@RequestMapping("/test")
 @RequiredArgsConstructor
 public class Test {
 
@@ -18,6 +24,7 @@ public class Test {
         DB 연결 확인 테스트용 코드.
         TODO - 삭제
      */
+    @Operation(summary = "유저 이름 반환", description = "유저 이름을 현재 시간과 함께 반환합니다.")
     @GetMapping("/test")
     @ResponseBody
     public String test() {

--- a/src/main/java/io/oopy/coding/service/TestService.java
+++ b/src/main/java/io/oopy/coding/service/TestService.java
@@ -17,6 +17,7 @@ public class TestService {
     public String getNowUserName() {
         User user = User.builder()
                 .name("테스트" + randomNumber())
+                .githubId(Integer.parseInt(randomNumber()))
                 .bio("소개")
                 .role("1")
                 .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,14 @@ spring:
       connection-timeout: 3000 # 3s (default 30s)
     validation-timeout: 2000 # 2s (default 5s)
 
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true


### PR DESCRIPTION
## 작업 이유
Swagger 적용
[Springdoc 공식문서](https://springdoc.org/)
  
해당 공식문서에서 annotation 사용법 잘 설명해주고 있으니 참고하시면 될 것 같습니다!
혹시나 springfox를 사용해보신 분들이 헷갈리실까봐, 기존 Annotation과 비교하여 정리해두었습니다.
- @Api → @Tag
- @ApiIgnore → @Parameter(hidden = true) or @Operation(hidden = true) or @Hidden
- @ApiImplicitParam → @Parameter
- @ApiImplicitParams → @Parameters
- @ApiModel → @Schema
- @ApiModelProperty(hidden = true) → @Schema(accessMode = READ_ONLY)
- @ApiModelProperty → @Schema
- @ApiOperation(value = "foo", notes = "bar") → @Operation(summary = "foo", description = "bar")
- @ApiParam → @Parameter
- @ApiResponse(code = 404, message = "foo") → @ApiResponse(responseCode = "404", description = "foo")

아래 url에서 확인할 수 있습니다.
- `/swagger` : docs UI에서 api 확인
- `/v3/api-docs` : Json 포맷으로 docs 확인 

## 작업 사항
1. 라이브러리 2가지 추가
```java
implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
implementation 'org.springframework.boot:spring-boot-starter-validation'
```

2. YAML 파일 설정
```yaml
springdoc:
  default-consumes-media-type: application/json;charset=UTF-8
  default-produces-media-type: application/json;charset=UTF-8
  swagger-ui:
    path: /swagger
    disable-swagger-default-url: true
    display-request-duration: true
    operations-sorter: alpha
  api-docs:
    groups:
      enabled: true
```

3. test api로 결과 확인
```java
@Tag(name = "테스트", description = "테스트용 API")
@RestController
@RequestMapping("/test")
@RequiredArgsConstructor
public class Test {

    private final TestService testService;

    /*
        유저의 이름을 현재 시간과 함께 반환.
        DB 연결 확인 테스트용 코드.
        TODO - 삭제
     */
    @Operation(summary = "유저 이름 반환", description = "유저 이름을 현재 시간과 함께 반환합니다.")
    @GetMapping("/test")
    @ResponseBody
    public String test() {
        return testService.getNowUserName();
    }
}
```
![image](https://github.com/80000Coding/80000Coding-Backend/assets/96044622/491bc139-9e21-4bcc-b2b6-4851887b6825)

## 이슈 연결

close #15 