### PR TITLE
✨ Github Action을 통해 Docker Hub에 올리는 작업 및 자동 배포 스크립트 작성

### DIFF
--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -27,7 +27,7 @@ jobs:
           tag_name: ${{ env.VERSION }}
           release_name: ${{ env.VERSION }}
         env:
-          GITHUB_TOKEN: ${{ GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: build docker

--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -1,0 +1,44 @@
+name: Publish Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docker:
+    name: Deploy Docker Image
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ secrets.DOCKER_REPO }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: set version from on push tags
+        run: |
+          echo "VERSION=${{ github.event.inputs.tags }}" >> $GITHUB_ENV
+      - name: create Github release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ GITHUB_TOKEN }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: build docker
+        run: ./gradlew bootBuildImage --imageName=palco
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish Docker Image
+        run: |
+          docker push $REPO
+          docker tag $REPO $REPO:${{ env.VERSION }}
+          docker push $REPO:${{ env.VERSION }}

--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: build docker
-        run: ./gradlew bootBuildImage --imageName=${{REPO}}
+        run: ./gradlew bootBuildImage --imageName=$REPO
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -5,8 +5,6 @@ on:
     tags:
       - 'v*.*.*'
 
-permissions: read-all|write-all
-
 jobs:
   docker:
     name: Deploy Docker Image
@@ -25,13 +23,6 @@ jobs:
           TAG=${{ github.event.ref }}
           VERSION=${TAG#refs/tags/}
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
-      - name: create Github release
-        uses: actions/create-release@v1
-        with:
-          tag_name: ${{ env.VERSION }}
-          release_name: ${{ env.VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: build docker

--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: build docker
-        run: ./gradlew bootBuildImage --imageName=palco
+        run: ./gradlew bootBuildImage --imageName=${{REPO}}
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions: read-all
+
 jobs:
   docker:
     name: Deploy Docker Image

--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -20,7 +20,9 @@ jobs:
           distribution: 'adopt'
       - name: set version from on push tags
         run: |
-          echo "VERSION=${{ github.event.inputs.tags }}" >> $GITHUB_ENV
+          TAG=${{ github.event.ref }}
+          VERSION=${TAG#refs/tags/}
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
       - name: create Github release
         uses: actions/create-release@v1
         with:

--- a/.github/workflows/develop-publish.yaml
+++ b/.github/workflows/develop-publish.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*.*.*'
 
-permissions: read-all
+permissions: read-all|write-all
 
 jobs:
   docker:

--- a/src/main/java/io/oopy/coding/common/config/SshDataSourceConfig.java
+++ b/src/main/java/io/oopy/coding/common/config/SshDataSourceConfig.java
@@ -2,7 +2,8 @@ package io.oopy.coding.common.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,18 +19,25 @@ import javax.sql.DataSource;
 public class SshDataSourceConfig {
     private final SshTunnelingInitializer initializer;
 
-    @Bean("dataSource")
-    @Primary
-    public DataSource dataSource(DataSourceProperties properties) {
+    @Value("${DB_URL}")
+    private String url;
 
+    @Value("${DB_USER_NAME}")
+    private String username;
+
+    @Value("${DB_PASSWORD}")
+    private String password;
+
+    @Bean(name="dataSource")
+    @Primary
+    @ConfigurationProperties("spring.datasource.hikari")
+    public DataSource dataSource() {
         Integer forwardedPort = initializer.buildSshConnection();  // ssh 연결 및 터널링 설정
-        String url = properties.getUrl().replace("[forwardedPort]", Integer.toString(forwardedPort));
-        log.info(url);
         return DataSourceBuilder.create()
                 .url(url)
-                .username(properties.getUsername())
-                .password(properties.getPassword())
-                .driverClassName(properties.getDriverClassName())
+                .username(username)
+                .password(password)
+                .driverClassName("com.mysql.cj.jdbc.Driver") // todo - env
                 .build();
     }
 

--- a/src/main/java/io/oopy/coding/common/config/SshDataSourceConfig.java
+++ b/src/main/java/io/oopy/coding/common/config/SshDataSourceConfig.java
@@ -7,12 +7,14 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 
 import javax.sql.DataSource;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
+@Profile("local")
 public class SshDataSourceConfig {
     private final SshTunnelingInitializer initializer;
 

--- a/src/main/java/io/oopy/coding/common/config/SshTunnelingInitializer.java
+++ b/src/main/java/io/oopy/coding/common/config/SshTunnelingInitializer.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
@@ -16,6 +17,7 @@ import java.util.Properties;
 @ConfigurationProperties(prefix = "ssh")
 @Validated
 @Slf4j
+@Profile("local")
 public class SshTunnelingInitializer {
 
     @Value("${ssh.host}")

--- a/src/main/java/io/oopy/coding/common/security/SecurityConfig.java
+++ b/src/main/java/io/oopy/coding/common/security/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,17 @@ spring.config.activate.on-profile: local
 server:
   port: 8081
 spring:
+  datasource:
+    hikari:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ${DB_URL}
+      username: ${DB_USER_NAME}
+      password: ${DB_PASSWORD}
+      maximum-pool-size: 5 # (default 10)
+      minimum-idle: 5 # (default 10)
+      max-lifetime: 1200000 # 20m (default 30m)
+      connection-timeout: 3000 # 3s (default 30s)
+      validation-timeout: 2000 # 2s (default 5s)
   jpa:
     database: MYSQL
     database-platform: org.hibernate.dialect.MySQL8Dialect
@@ -14,18 +25,10 @@ spring:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USER_NAME}
-    password: ${DB_PASSWORD}
-    hikari:
-      driver-class-name: com.mysql.cj.jdbc.Driver
-      maximum-pool-size: 1 # (default 10)
-      minimum-idle: 1 # (default 10)
-      idle-timeout: 60000 # 1m (default 10m)
-      max-lifetime: 1200000 # 20m (default 30m)
-      connection-timeout: 3000 # 3s (default 30s)
-    validation-timeout: 2000 # 2s (default 5s)
+logging:
+  level:
+    com.zaxxer.hikari.HikariConfig: DEBUG
+#    com.zaxxer.hikari: TRACE
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
@@ -64,17 +67,19 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true
   datasource:
+    hikari:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ${DB_URL}
+      username: ${DB_USER_NAME}
+      password: ${DB_PASSWORD}
+      maximum-pool-size: 15 # (default 10)
+      minimum-idle: 15 # (default 10)
+      max-lifetime: 1200000 # 20m (default 30m)
+      connection-timeout: 10000 # 10s (default 30s)
+      validation-timeout: 2000 # 2s (default 5s)
     url: ${DB_URL}
     username: ${DB_USER_NAME}
     password: ${DB_PASSWORD}
-    hikari:
-      driver-class-name: com.mysql.cj.jdbc.Driver
-      maximum-pool-size: 1 # (default 10)
-      minimum-idle: 1 # (default 10)
-      idle-timeout: 60000 # 1m (default 10m)
-      max-lifetime: 1200000 # 20m (default 30m)
-      connection-timeout: 3000 # 3s (default 30s)
-    validation-timeout: 2000 # 2s (default 5s)
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,57 @@
+---
+spring.config.activate.on-profile: local
+
+server:
+  port: 8081
+spring:
+  jpa:
+    database: MYSQL
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
+    generate-ddl: false
+    hibernate:
+      ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER_NAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      maximum-pool-size: 1 # (default 10)
+      minimum-idle: 1 # (default 10)
+      idle-timeout: 60000 # 1m (default 10m)
+      max-lifetime: 1200000 # 20m (default 30m)
+      connection-timeout: 3000 # 3s (default 30s)
+    validation-timeout: 2000 # 2s (default 5s)
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true
+
 ssh:
   host: ${SSH_HOST}
   user: ${SSH_USER}
   port: ${SSH_PORT}
   pem: ${SSH_PEM}
   database-port: ${SSH_DATABASE_PORT}
+
 ---
-spring.config.activate.on-profile: local
+spring.config.activate.on-profile: develop
 
 server:
   port: 8081
+  forward-headers-strategy: FRAMEWORK
 spring:
   jpa:
     database: MYSQL


### PR DESCRIPTION
## 작업 이유
- ec2 instance에 spring boot application을 편하게 배포할 수 있는 환경 구축

## 작업 사항

- [github action] workflow 파일 생성 및 코드 작성
- spring active profile - local, develop 분리. 이유는, ec2 instance에 올라가는 어플리케이션에서는 ssh 터널링이 필요 없을 예정이기 때문
- [서버] nginx로 reverse proxy 적용
- [서버] 배포 자동화 스크립트 작업. (github action로 자동배포까지 적용은 todo)
- reverse proxy가 적용된 경우, springdoc swagger에서 prefix url을 적용하지 않는 문제 해결 (application.yaml에 forward-headers-strategy: FRAMEWORK 참고)


### 사용방법
1. github action trigger를 위해 tag 생성 및 release
![image](https://github.com/80000Coding/80000Coding-Backend/assets/46598292/cb451b9f-3da2-4adb-a9a2-f8f9cee424d8)
[주의 : tag는 [major].[minor].[patch] 인데, patch만 +1 해주세요. target은 꼭 dev로 !! ]

2. 작성해놓은 스크립트 실행
github action이 성공적으로 끝난 후의 상황.

docker image hub에서 image를 pull해오고, docker container를 띄우는 스크립트를 작성
/home/백엔드 에 run_80000_coding_backend.sh 참고 (.env도 있습니다)
아래 내용 그대로 실행하면 됩니다.
```
sh run_80000_coding_backend.sh
```

배포 링크 : https://heyinsa.kr/palco-backend/swagger-ui/index.html

### 문제 해결 
1. reverse proxy가 적용된 경우, springdoc swagger에서 prefix url을 적용하지 않는 문제
https://binux.tistory.com/161 참고함

X-Forwarded-Prefix 헤더를 통해 리다이렉트 url에 원하는 prefix를 붙일 수 있는 것으로 보임.
![image](https://github.com/80000Coding/80000Coding-Backend/assets/46598292/db4b7f52-273f-4303-a487-71868207e603)
swagger-initializer.js에 configUrl 부분을 보면, "/v3/api-docs/swagger-config"로 나와있는게 문제로 보임. 
저 부분 앞에 prefix가 붙는지 확인하는 테스트

![image](https://github.com/80000Coding/80000Coding-Backend/assets/46598292/2655de7c-1463-42a9-951b-0ece7ecdf9b1)
테스트 완료.

nginx에도 설정 완료
![image](https://github.com/80000Coding/80000Coding-Backend/assets/46598292/7ef32ff8-ed55-49c9-b7d4-7d8fd9459b9a)

## 이슈 연결
close #24 