### PR TITLE
✨ AccessTokenResolver null 허용 옵션 추가

### DIFF
--- a/src/main/java/io/oopy/coding/api/user/controller/UserAPI.java
+++ b/src/main/java/io/oopy/coding/api/user/controller/UserAPI.java
@@ -4,13 +4,13 @@ import io.oopy.coding.api.user.service.UserAuthService;
 import io.oopy.coding.common.resolver.access.AccessToken;
 import io.oopy.coding.common.resolver.access.AccessTokenInfo;
 import io.oopy.coding.common.response.SuccessResponse;
+import io.oopy.coding.common.security.authentication.CustomUserDetails;
+import io.oopy.coding.common.util.cookie.CookieUtil;
 import io.oopy.coding.common.util.jwt.AuthConstants;
+import io.oopy.coding.common.util.jwt.entity.JwtUserInfo;
 import io.oopy.coding.common.util.jwt.exception.AuthErrorCode;
 import io.oopy.coding.common.util.jwt.exception.AuthErrorException;
 import io.oopy.coding.domain.user.dto.UserAuthReq;
-import io.oopy.coding.common.util.cookie.CookieUtil;
-import io.oopy.coding.common.util.jwt.entity.JwtUserInfo;
-import io.oopy.coding.common.security.authentication.CustomUserDetails;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -26,7 +26,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
-import static io.oopy.coding.common.util.jwt.AuthConstants.*;
+import static io.oopy.coding.common.util.jwt.AuthConstants.ACCESS_TOKEN;
+import static io.oopy.coding.common.util.jwt.AuthConstants.REFRESH_TOKEN;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -96,4 +97,6 @@ public class UserAPI {
 
         return ResponseEntity.ok(user);
     }
+
+
 }

--- a/src/main/java/io/oopy/coding/common/config/security/SecurityConfig.java
+++ b/src/main/java/io/oopy/coding/common/config/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
             "/",
             "/favicon.ico",
             "/api-docs/**",
-            "/test/**",
+            "/api/v1/users/test/**",
             "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
             "/api/v1/users/login", "/api/v1/users/refresh",
             "/api/v1/auth/login/**", "/api/v1/auth/signup"
@@ -57,7 +57,9 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .cors((cors) -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeHttpRequests(

--- a/src/main/java/io/oopy/coding/common/config/security/SecurityFilterConfig.java
+++ b/src/main/java/io/oopy/coding/common/config/security/SecurityFilterConfig.java
@@ -1,5 +1,6 @@
 package io.oopy.coding.common.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oopy.coding.common.security.authentication.UserDetailServiceImpl;
 import io.oopy.coding.common.security.filter.JwtAuthenticationFilter;
 import io.oopy.coding.common.security.filter.JwtExceptionFilter;
@@ -22,9 +23,11 @@ public class SecurityFilterConfig {
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
 
+    private final ObjectMapper objectMapper;
+
     @Bean
     public JwtExceptionFilter jwtExceptionFilter() {
-        return new JwtExceptionFilter();
+        return new JwtExceptionFilter(objectMapper);
     }
 
     @Bean

--- a/src/main/java/io/oopy/coding/common/resolver/access/AccessTokenInfo.java
+++ b/src/main/java/io/oopy/coding/common/resolver/access/AccessTokenInfo.java
@@ -5,7 +5,17 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * AccessTokenInfoResolver에서 AccessToken 객체를 생성할 때 사용하는 어노테이션
+ * @see AccessTokenInfoResolver
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AccessTokenInfo {
+    /**
+     * accessToken이 필수인지 여부
+     * 기본 값은 true, accessToken이 없다면 AuthErrorException 발생
+     * 만약 accessToken이 null일 때, AuthErrorException을 발생시키지 않고 null을 반환하고 싶다면 false로 설정
+     */
+    boolean required() default true;
 }

--- a/src/main/java/io/oopy/coding/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/oopy/coding/common/security/filter/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final CookieUtil cookieUtil;
 
     private final List<String> jwtIgnoreUrls = List.of(
-            "/test",
+            "/api/v1/users/test/**",
             "/api/v1/users/login",
             "/api/v1/users/refresh",
             "/v3/api-docs/**", "/swagger-ui/**", "/swagger",

--- a/src/main/java/io/oopy/coding/common/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/io/oopy/coding/common/security/filter/JwtExceptionFilter.java
@@ -10,15 +10,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;

--- a/src/main/java/io/oopy/coding/common/util/converter/LegacyEnumValueConvertUtils.java
+++ b/src/main/java/io/oopy/coding/common/util/converter/LegacyEnumValueConvertUtils.java
@@ -14,7 +14,7 @@ public class LegacyEnumValueConvertUtils {
     public static <T extends Enum<T> & LegacyCommonType> T ofLegacyCode(Class<T> enumClass, String code) {
         if (!StringUtils.hasText(code)) return null;
         return EnumSet.allOf(enumClass).stream()
-                .filter(e -> e.name().equals(code))
+                .filter(e -> e.getCode().equals(code))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException(
                         String.format("enum=[%s], code=[%s]가 존재하지 않습니다.", enumClass.getName(), code))); // TODO : 공통 예외로 변경

--- a/src/main/java/io/oopy/coding/common/util/jwt/JwtUtil.java
+++ b/src/main/java/io/oopy/coding/common/util/jwt/JwtUtil.java
@@ -1,10 +1,9 @@
 package io.oopy.coding.common.util.jwt;
 
-import io.oopy.coding.common.util.jwt.exception.AuthErrorException;
 import io.oopy.coding.common.util.jwt.entity.JwtUserInfo;
+import io.oopy.coding.common.util.jwt.exception.AuthErrorException;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 
 public interface JwtUtil {
     /**

--- a/src/main/java/io/oopy/coding/common/util/jwt/JwtUtilImpl.java
+++ b/src/main/java/io/oopy/coding/common/util/jwt/JwtUtilImpl.java
@@ -1,6 +1,7 @@
 package io.oopy.coding.common.util.jwt;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
 import io.oopy.coding.common.util.DateUtil;
 import io.oopy.coding.common.util.jwt.exception.AuthErrorCode;
 import io.oopy.coding.common.util.jwt.exception.AuthErrorException;
@@ -30,7 +31,9 @@ public class JwtUtilImpl implements JwtUtil {
     private static final String ROLE = "role";
     private static final String GITHUB_ID = "githubId";
 
-    private final String jwtSecretKey;
+    private final Key signatureKey;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
     private final Duration accessTokenExpirationTime;
     private final Duration refreshTokenExpirationTime;
     private final Duration signupAccessTokenExpirationTime;
@@ -41,8 +44,11 @@ public class JwtUtilImpl implements JwtUtil {
             @Value("${jwt.token.access-expiration-time}") Duration accessTokenExpirationTime,
             @Value("${jwt.token.refresh-expiration-time}") Duration refreshTokenExpirationTime,
             @Value("${jwt.token.signup-access-expiration-time}") Duration signupAccessTokenExpirationTime,
-            @Value("${jwt.token.signup-refresh-expiration-time}") Duration signupRefreshTokenExpireTime) {
-        this.jwtSecretKey = jwtSecretKey;
+            @Value("${jwt.token.signup-refresh-expiration-time}") Duration signupRefreshTokenExpireTime)
+    {
+        final byte[] secretKeyBytes = Base64.getDecoder().decode(jwtSecretKey);
+        this.signatureKey = Keys.hmacShaKeyFor(secretKeyBytes);
+
         this.accessTokenExpirationTime = accessTokenExpirationTime;
         this.refreshTokenExpirationTime = refreshTokenExpirationTime;
         this.signupAccessTokenExpirationTime = signupAccessTokenExpirationTime;
@@ -57,7 +63,6 @@ public class JwtUtilImpl implements JwtUtil {
         return "";
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public String generateAccessToken(JwtUserInfo user) {
         final Date now = new Date();
@@ -65,7 +70,7 @@ public class JwtUtilImpl implements JwtUtil {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
-                .signWith(SignatureAlgorithm.HS256, createSignature())
+                .signWith(signatureKey, signatureAlgorithm)
                 .setExpiration(createExpireDate(now, accessTokenExpirationTime.toMillis()))
                 .compact();
     }
@@ -77,7 +82,7 @@ public class JwtUtilImpl implements JwtUtil {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
-                .signWith(SignatureAlgorithm.HS256, createSignature())
+                .signWith(signatureKey, signatureAlgorithm)
                 .setExpiration(createExpireDate(now, refreshTokenExpirationTime.toMillis()))
                 .compact();
     }
@@ -89,7 +94,7 @@ public class JwtUtilImpl implements JwtUtil {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
-                .signWith(SignatureAlgorithm.HS256, createSignature())
+                .signWith(signatureKey, signatureAlgorithm)
                 .setExpiration(createExpireDate(now, signupAccessTokenExpirationTime.toMillis()))
                 .compact();
     }
@@ -101,7 +106,7 @@ public class JwtUtilImpl implements JwtUtil {
         return Jwts.builder()
                 .setHeader(createHeader())
                 .setClaims(createClaims(user))
-                .signWith(SignatureAlgorithm.HS256, createSignature())
+                .signWith(signatureKey, signatureAlgorithm)
                 .setExpiration(createExpireDate(now, signupRefreshTokenExpirationTime.toMillis()))
                 .compact();
     }
@@ -167,19 +172,13 @@ public class JwtUtilImpl implements JwtUtil {
                 GITHUB_ID, dto.githubId());
     }
 
-    private Key createSignature() {
-        byte[] secretKeyBytes = Base64.getDecoder().decode(jwtSecretKey);
-        return new SecretKeySpec(secretKeyBytes, SignatureAlgorithm.HS256.getJcaName());
-    }
-
     private Date createExpireDate(final Date now, long expirationTime) {
         return new Date(now.getTime() + expirationTime);
     }
 
-    @SuppressWarnings("deprecation")
     private Claims getClaimsFromToken(String token) {
-        return Jwts.parser()
-                .setSigningKey(Base64.getDecoder().decode(jwtSecretKey))
+        return Jwts.parserBuilder()
+                .setSigningKey(signatureKey).build()
                 .parseClaimsJws(token)
                 .getBody();
     }

--- a/src/main/java/io/oopy/coding/common/util/redis/forbidden/ForbiddenTokenService.java
+++ b/src/main/java/io/oopy/coding/common/util/redis/forbidden/ForbiddenTokenService.java
@@ -1,19 +1,17 @@
 package io.oopy.coding.common.util.redis.forbidden;
 
 import io.oopy.coding.common.resolver.access.AccessToken;
-import io.oopy.coding.common.util.jwt.JwtUtil;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Date;
 
 @Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Component
+@Service
 public class ForbiddenTokenService {
     private final ForbiddenTokenRepository forbiddenTokenRepository;
 

--- a/src/main/java/io/oopy/coding/common/util/redis/refresh/RefreshTokenServiceImpl.java
+++ b/src/main/java/io/oopy/coding/common/util/redis/refresh/RefreshTokenServiceImpl.java
@@ -1,17 +1,17 @@
 package io.oopy.coding.common.util.redis.refresh;
 
+import io.oopy.coding.common.util.jwt.JwtUtil;
 import io.oopy.coding.common.util.jwt.entity.JwtUserInfo;
 import io.oopy.coding.common.util.jwt.exception.AuthErrorCode;
 import io.oopy.coding.common.util.jwt.exception.AuthErrorException;
-import io.oopy.coding.common.util.jwt.JwtUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
 @Slf4j
-@Component
+@Service
 public class RefreshTokenServiceImpl implements RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,13 @@ spring:
   data.redis:
     host: localhost
     port: 6379
+  security: #OAuth2 연동 어플리케이션 정보 (TODO : 운영 어플리케이션 정보로 수정 필요)
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${OAUTH2_GITHUB_CLIENT_ID}
+            client-secret: ${OAUTH2_GITHUB_CLIENT_SECRET}
 
 logging:
   level:
@@ -50,11 +57,13 @@ springdoc:
       enabled: true
 
 jwt:
-  secret: exampleSecretKeyForSpringBootProjectAtSubRepository # TODO 운영 환경에서 수정
+  secret: exampleSecretKeyForSpringBootProjectAtSubRepository
   token:
     # milliseconds 단위
     access-expiration-time: 1800000 # 30m (30 * 60 * 1000)
     refresh-expiration-time: 604800000 # 7d (7 * 24 * 60 * 60 * 1000)
+    signup-access-expiration-time: 600000 # 10m (10 * 60 * 1000)
+    signup-refresh-expiration-time: 600000 # 10m (10 * 60 * 1000)
 
 ssh:
   host: ${SSH_HOST}
@@ -119,7 +128,7 @@ springdoc:
       enabled: true
 
 jwt:
-  secret: ${JWT_SECRET} # TODO 운영 환경에서 수정
+  secret: ${JWT_SECRET}
   token:
     # milliseconds 단위
     access-expiration-time: 1800000 # 30m (30 * 60 * 1000)


### PR DESCRIPTION
## 작업 이유
- AccessTokenInfo 어노테이션의 null 허용을 위한 옵션 추가

하긴 했는데, 비로그인/로그인 유저 모두 받아야 하는 상황 아니라면, 되도록 `@AuthenticationPrincipal` 사용해주세요.

## 작업 사항
### 1️⃣ null 허용 안 하는 경우
```java
public ResponseEntity<?> test(@AccessTokenInfo AccessToken accessToken)

// 혹은

public ResponseEntity<?> test(@AccessTokenInfo(required = true) AccessToken accessToken)
```

### 2️⃣ null 허용하는 경우
```java
public ResponseEntity<?> test(@AccessTokenInfo(required = false) AccessToken accessToken)
```
- accessToken이 있으면 AccessToken 객체를 돌려줌
- accessToken이 없으면 null 객체 반환
- null 허용 시, 클라이언트가 null 가드 조건 필수적으로 고려해야 함

## 이슈 연결
close #40 