### PR TITLE
fix/댓글 관련 Swagger옵션 수정

### DIFF
--- a/src/main/java/io/oopy/coding/api/comment/controller/CommentController.java
+++ b/src/main/java/io/oopy/coding/api/comment/controller/CommentController.java
@@ -40,7 +40,7 @@ public class CommentController {
     @Operation(summary = "댓글 수정", description = "comment_id 댓글 수정")
     @PatchMapping("/{comment_id}")
     @PreAuthorize("isAuthenticated() && @authorManager.isCommentAuthor(#authentication.getPrincipal(), #commentId)")
-    public ResponseEntity<?> updateComment(@Parameter(name = "content_id", description = "게시글 번호", hidden = true) @PathVariable(name = "content_id") Long contentId,
+    public ResponseEntity<?> updateComment(@Parameter(name = "content_id", description = "게시글 번호") @PathVariable(name = "content_id") Long contentId,
                                            @Parameter(name = "comment_id", description = "댓글 번호") @PathVariable(name = "comment_id") Long commentId,
                                            @Valid @RequestBody UpdateCommentReq request,
                                            @AuthenticationPrincipal CustomUserDetails securityUser) {
@@ -50,7 +50,7 @@ public class CommentController {
     @Operation(summary = "댓글 삭제", description = "comment_id 댓글 삭제. Soft Delete")
     @DeleteMapping("/{comment_id}")
     @PreAuthorize("isAuthenticated() && @authorManager.isCommentAuthor(#authentication.getPrincipal(), #commentId)")
-    public ResponseEntity<?> deleteComment(@Parameter(name = "content_id", description = "게시글 번호", hidden = true) @PathVariable(name = "content_id") Long contentId,
+    public ResponseEntity<?> deleteComment(@Parameter(name = "content_id", description = "게시글 번호") @PathVariable(name = "content_id") Long contentId,
                                            @Parameter(name = "comment_id", description = "댓글 번호") @PathVariable(name = "comment_id") Long commentId,
                                            @AuthenticationPrincipal CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(commentService.deleteComment(commentId, securityUser)));


### PR DESCRIPTION
## 작업 이유
1. url상에서 content_id를 받지만, Swagger상에서 받지 않도록 되어 있어서 수정
<img width="1392" alt="스크린샷 2024-02-22 오후 3 54 06" src="https://github.com/80000Coding/80000Coding-Backend/assets/44596433/2fe929ce-004e-48dd-bb52-3ccf24906956">

## 작업 사항
1. swagger 설정
> - 변경 이전
> <img width="1286" alt="스크린샷 2024-02-22 오후 3 49 41" src="https://github.com/80000Coding/80000Coding-Backend/assets/44596433/bc60fb05-2349-460d-b0a8-b579d41040a5">
>
> - 변경 이후
> <img width="1169" alt="스크린샷 2024-02-22 오후 3 55 45" src="https://github.com/80000Coding/80000Coding-Backend/assets/44596433/32cf4bae-b383-4620-aa26-440b9ee60afe">
>
> hidden=true 옵션 제거

## 이슈 연결
