### PR TITLE
📢 QueryDslUtil을 활용한 match_against 사용법

### DIFF
--- a/src/main/java/io/oopy/coding/common/config/MySqlFunctionContributor.java
+++ b/src/main/java/io/oopy/coding/common/config/MySqlFunctionContributor.java
@@ -1,0 +1,42 @@
+package io.oopy.coding.common.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * MySQL의 match_against 함수를 사용하기 위한 FunctionContributor
+ *
+ * <pre>
+ * Boolean Mode 검색 예시
+ * {@code
+ * public List<Entity> findAllBy(final String entityNameWord, final String entityAttrWord) {
+ *    return queryFactory.selectFrom(entity)
+ *        .where(matchAgainst(entity.name, entity.attr, entityAttrWord))
+ *        .fetch();
+ * }
+ *
+ * public static BooleanExpression matchAgainst(final StringPath c1, final StringPath c2, final String target) {
+ *      if (!StringUtils.hasText(target)) { return null; }
+ *      String template = "'" + target + "*'";
+ *      return Expressions.booleanTemplate( "function('match_against', {0}, {1}, {2})", c1, c2, template);
+ * }
+ * </pre>
+ *
+ * @see <a href="https://velog.io/@ttomy/%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%A0%95%EC%9D%98-dialectmatch-against%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0">참고 블로그</a>
+ */
+public class MySqlFunctionContributor implements FunctionContributor {
+    private static final String ONE_COLUMN_NATURAL_PATTERN = "match(?1) against(?2 in natural language mode)";
+    private static final String TWO_COLUMN_BOOLEAN_PATTERN = "match(?1, ?2) against(?3 in boolean mode)";
+
+    @Override
+    public void contributeFunctions(final FunctionContributions functionContributions) {
+        SqmFunctionRegistry registry = functionContributions.getFunctionRegistry();
+        TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
+
+        registry.registerPattern( "two_column_natural", TWO_COLUMN_BOOLEAN_PATTERN, typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN) );
+        registry.registerPattern("one_column_natural", ONE_COLUMN_NATURAL_PATTERN, typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN));
+    }
+}

--- a/src/main/java/io/oopy/coding/common/config/MySqlFunctionContributor.java
+++ b/src/main/java/io/oopy/coding/common/config/MySqlFunctionContributor.java
@@ -29,6 +29,8 @@ import org.hibernate.type.spi.TypeConfiguration;
  */
 public class MySqlFunctionContributor implements FunctionContributor {
     private static final String ONE_COLUMN_NATURAL_PATTERN = "match(?1) against(?2 in natural language mode)";
+    private static final String TWO_COLUMN_NATURAL_PATTERN = "match(?1, ?2) against(?3 in natural language mode)";
+    private static final String ONE_COLUMN_BOOLEAN_PATTERN = "match(?1) against(?2 in boolean mode)";
     private static final String TWO_COLUMN_BOOLEAN_PATTERN = "match(?1, ?2) against(?3 in boolean mode)";
 
     @Override
@@ -36,7 +38,9 @@ public class MySqlFunctionContributor implements FunctionContributor {
         SqmFunctionRegistry registry = functionContributions.getFunctionRegistry();
         TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
 
-        registry.registerPattern( "two_column_natural", TWO_COLUMN_BOOLEAN_PATTERN, typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN) );
         registry.registerPattern("one_column_natural", ONE_COLUMN_NATURAL_PATTERN, typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN));
+        registry.registerPattern("two_column_natural", TWO_COLUMN_NATURAL_PATTERN, typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN));
+        registry.registerPattern( "one_column_boolean", ONE_COLUMN_BOOLEAN_PATTERN, typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN) );
+        registry.registerPattern( "two_column_boolean", TWO_COLUMN_BOOLEAN_PATTERN, typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN) );
     }
 }

--- a/src/main/java/io/oopy/coding/common/util/QueryDslUtil.java
+++ b/src/main/java/io/oopy/coding/common/util/QueryDslUtil.java
@@ -1,0 +1,100 @@
+package io.oopy.coding.common.util;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
+import org.springframework.util.StringUtils;
+
+public class QueryDslUtil {
+    /**
+     * match_against 함수를 통해 c1 컬럼의 target을 natural mode로 탐색한다.
+     * @param c1 : 검색할 컬럼
+     * @param target : 검색어
+     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
+     * <pre>
+     * {@code
+     * public Entity findTarget(String target) {
+     *      QEntity entity = QEntity.entity;
+     *
+     *      return queryFactory
+     *             .fromSelect(entity)
+     *             .where(QueryDslUtil.matchAgainstNaturalMode(entity.name, target));
+     * }
+     * }
+     * </pre>
+     */
+    public static BooleanExpression matchAgainstNaturalMode(final StringPath c1, final String target) {
+        if (!StringUtils.hasText(target)) { return null; }
+        return Expressions.booleanTemplate( "function('one_column_natural', {0}, {1})", c1, target);
+    }
+
+    /**
+     * match_against 함수를 통해 c1, c2 컬럼의 target을 natural mode로 탐색한다.
+     * @param c1 : 검색할 컬럼1
+     * @param c2 : 검색할 컬럼2
+     * @param target : 검색어
+     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
+     * <pre>
+     * {@code
+     * public Entity findTarget(String target) {
+     *   QEntity entity = QEntity.entity;
+     *
+     *   return queryFactory
+     *       .fromSelect(entity)
+     *       .where(QueryDslUtil.matchAgainstNaturalMode(entity.name, entity.attr, target));
+     * }
+     * }
+     */
+    public static BooleanExpression matchAgainstNaturalMode(final StringPath c1, final StringPath c2, final String target) {
+        if (!StringUtils.hasText(target)) { return null; }
+        String template = "'" + target + "*'";
+        return Expressions.booleanTemplate( "function('two_column_natural', {0}, {1}, {2})", c1, c2, template);
+    }
+
+    /**
+     * match_against 함수를 통해 c1 컬럼의 target을 boolean mode로 탐색한다.
+     * @param c1 : 검색할 컬럼
+     * @param target : 검색어
+     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
+     * <pre>
+     * {@code
+     * public Entity findTarget(String target) {
+     *     QEntity entity = QEntity.entity;
+     *
+     *     return queryFactory
+     *     .fromSelect(entity)
+     *     .where(QueryDslUtil.matchAgainstBooleanMode(entity.name, target));
+     * }
+     * }
+     * </pre>
+     */
+    public static BooleanExpression matchAgainstBooleanMode(final StringPath c1, final String target) {
+        if (!StringUtils.hasText(target)) { return null; }
+        String template = "'" + target + "*'";
+        return Expressions.booleanTemplate( "function('one_column_boolean', {0}, {1})", c1, template);
+    }
+
+    /**
+     * match_against 함수를 통해 c1, c2 컬럼의 target을 boolean mode로 탐색한다.
+     * @param c1 : 검색할 컬럼1
+     * @param c2 : 검색할 컬럼2
+     * @param target : 검색어
+     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
+     * <pre>
+     * {@code
+     * public Entity findTarget(String target) {
+     *     QEntity entity = QEntity.entity;
+     *
+     *     return queryFactory
+     *     .fromSelect(entity)
+     *     .where(QueryDslUtil.matchAgainstBooleanMode(entity.name, entity.attr, target));
+     * }
+     * }
+     * </pre>
+     */
+    public static BooleanExpression matchAgainstBooleanMode(final StringPath c1, final StringPath c2, final String target) {
+        if (!StringUtils.hasText(target)) { return null; }
+        String template = "'" + target + "*'";
+        return Expressions.booleanTemplate( "function('two_column_boolean', {0}, {1}, {2})", c1, c2, template);
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+io.oopy.coding.common.config.MySqlFunctionContributor


### PR DESCRIPTION
## 작업 이유
- MySQL `Full_Text_Index` 적용 시, QueryDsl에서 사용하기 위해 MySQL 방언 사용자 정의 함수 선언

## 작업 사항
```java
public class QueryDslUtil {
    /**
     * match_against 함수를 통해 c1 컬럼의 target을 natural mode로 탐색한다.
     * @param c1 : 검색할 컬럼
     * @param target : 검색어
     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
     * <pre>
     * {@code
     * public Entity findTarget(String target) {
     *      QEntity entity = QEntity.entity;
     *
     *      return queryFactory
     *             .fromSelect(entity)
     *             .where(QueryDslUtil.matchAgainstNaturalMode(entity.name, target));
     * }
     * }
     * </pre>
     */
    public static BooleanExpression matchAgainstNaturalMode(final StringPath c1, final String target) {
        if (!StringUtils.hasText(target)) { return null; }
        return Expressions.booleanTemplate( "function('one_column_natural', {0}, {1})", c1, target);
    }

    /**
     * match_against 함수를 통해 c1, c2 컬럼의 target을 natural mode로 탐색한다.
     * @param c1 : 검색할 컬럼1
     * @param c2 : 검색할 컬럼2
     * @param target : 검색어
     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
     * <pre>
     * {@code
     * public Entity findTarget(String target) {
     *   QEntity entity = QEntity.entity;
     *
     *   return queryFactory
     *       .fromSelect(entity)
     *       .where(QueryDslUtil.matchAgainstNaturalMode(entity.name, entity.attr, target));
     * }
     * }
     */
    public static BooleanExpression matchAgainstNaturalMode(final StringPath c1, final StringPath c2, final String target) {
        if (!StringUtils.hasText(target)) { return null; }
        String template = "'" + target + "*'";
        return Expressions.booleanTemplate( "function('two_column_natural', {0}, {1}, {2})", c1, c2, template);
    }

    /**
     * match_against 함수를 통해 c1 컬럼의 target을 boolean mode로 탐색한다.
     * @param c1 : 검색할 컬럼
     * @param target : 검색어
     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
     * <pre>
     * {@code
     * public Entity findTarget(String target) {
     *     QEntity entity = QEntity.entity;
     *
     *     return queryFactory
     *     .fromSelect(entity)
     *     .where(QueryDslUtil.matchAgainstBooleanMode(entity.name, target));
     * }
     * }
     * </pre>
     */
    public static BooleanExpression matchAgainstBooleanMode(final StringPath c1, final String target) {
        if (!StringUtils.hasText(target)) { return null; }
        String template = "'" + target + "*'";
        return Expressions.booleanTemplate( "function('one_column_boolean', {0}, {1})", c1, template);
    }

    /**
     * match_against 함수를 통해 c1, c2 컬럼의 target을 boolean mode로 탐색한다.
     * @param c1 : 검색할 컬럼1
     * @param c2 : 검색할 컬럼2
     * @param target : 검색어
     * @return : BooleanExpression (target이 null이거나 공백 문자열이면 null 반환)
     * <pre>
     * {@code
     * public Entity findTarget(String target) {
     *     QEntity entity = QEntity.entity;
     *
     *     return queryFactory
     *     .fromSelect(entity)
     *     .where(QueryDslUtil.matchAgainstBooleanMode(entity.name, entity.attr, target));
     * }
     * }
     * </pre>
     */
    public static BooleanExpression matchAgainstBooleanMode(final StringPath c1, final StringPath c2, final String target) {
        if (!StringUtils.hasText(target)) { return null; }
        String template = "'" + target + "*'";
        return Expressions.booleanTemplate( "function('two_column_boolean', {0}, {1}, {2})", c1, c2, template);
    }
}
```
- `full_text_index`는 여러 컬럼을 동시에 걸 수도 있기에, 자연어 검색 모드와 불린 모드 각각 컬럼 1개, 2개 있는 경우를 지원합니다.
- 사용 예시는 모두 문서화 해두었으니 참고바랍니다.

## 이슈 연결
