### PR TITLE
[Fix] Comment, ContentMark 응답 일부 수정

### DIFF
--- a/src/main/java/io/oopy/coding/api/comment/controller/CommentController.java
+++ b/src/main/java/io/oopy/coding/api/comment/controller/CommentController.java
@@ -39,21 +39,21 @@ public class CommentController {
 
     @Operation(summary = "댓글 수정", description = "comment_id 댓글 수정")
     @PatchMapping("/{comment_id}")
-    @PreAuthorize("isAuthenticated() && @authorManager.isCommentAuthor(#authentication.getPrincipal(), #commentId)")
+    @PreAuthorize("isAuthenticated() && @authorManager.isCommentAuthor(authentication.getPrincipal(), #commentId)")
     public ResponseEntity<?> updateComment(@Parameter(name = "content_id", description = "게시글 번호") @PathVariable(name = "content_id") Long contentId,
                                            @Parameter(name = "comment_id", description = "댓글 번호") @PathVariable(name = "comment_id") Long commentId,
                                            @Valid @RequestBody UpdateCommentReq request,
                                            @AuthenticationPrincipal CustomUserDetails securityUser) {
-        return ResponseEntity.ok().body(SuccessResponse.from(commentService.updateComment(commentId, request, securityUser)));
+        return ResponseEntity.ok().body(SuccessResponse.from(commentService.updateComment(contentId, commentId, request, securityUser)));
     }
 
     @Operation(summary = "댓글 삭제", description = "comment_id 댓글 삭제. Soft Delete")
     @DeleteMapping("/{comment_id}")
-    @PreAuthorize("isAuthenticated() && @authorManager.isCommentAuthor(#authentication.getPrincipal(), #commentId)")
+    @PreAuthorize("isAuthenticated() && @authorManager.isCommentAuthor(authentication.getPrincipal(), #commentId)")
     public ResponseEntity<?> deleteComment(@Parameter(name = "content_id", description = "게시글 번호") @PathVariable(name = "content_id") Long contentId,
                                            @Parameter(name = "comment_id", description = "댓글 번호") @PathVariable(name = "comment_id") Long commentId,
                                            @AuthenticationPrincipal CustomUserDetails securityUser) {
-        return ResponseEntity.ok().body(SuccessResponse.from(commentService.deleteComment(commentId, securityUser)));
+        return ResponseEntity.ok().body(SuccessResponse.from(commentService.deleteComment(contentId, commentId, securityUser)));
     }
 
 }

--- a/src/main/java/io/oopy/coding/api/comment/service/CommentService.java
+++ b/src/main/java/io/oopy/coding/api/comment/service/CommentService.java
@@ -106,7 +106,6 @@ public class CommentService {
      */
     @Transactional
     public DeleteCommentRes deleteComment(Long contentId, Long commentId, CustomUserDetails securityUser) {
-        System.out.println("repository result = " + contentRepository.existsByIdAndDeleteAtIsNull(contentId));
         if (!contentRepository.existsByIdAndDeleteAtIsNull(contentId)) {
             throw new ContentErrorException(ContentErrorCode.INVALID_CONTENT_ID);
         }

--- a/src/main/java/io/oopy/coding/api/comment/service/CommentService.java
+++ b/src/main/java/io/oopy/coding/api/comment/service/CommentService.java
@@ -34,16 +34,16 @@ public class CommentService {
      * @param contentId
      */
     @Transactional
-    public List<CommentDTO> getComments(Long contentId) {
+    public List<GetCommentRes> getComments(Long contentId) {
         contentRepository.findById(contentId)
                 .orElseThrow(() -> new ContentErrorException(ContentErrorCode.INVALID_CONTENT_ID));
 
         List<Comment> comments = commentRepository.findCommentsByContentId(contentId);
 
-        List<CommentDTO> response = new ArrayList<>();
+        List<GetCommentRes> response = new ArrayList<>();
 
         for (Comment comment : comments) {
-            CommentDTO dto = CommentDTO.fromEntity(comment);
+            GetCommentRes dto = GetCommentRes.fromEntity(comment);
             response.add(dto);
         }
 
@@ -84,7 +84,11 @@ public class CommentService {
      * 댓글 수정
      * @param req
      */
-    public UpdateCommentRes updateComment(Long commentId, UpdateCommentReq req, CustomUserDetails securityUser) {
+    public UpdateCommentRes updateComment(Long contentId, Long commentId, UpdateCommentReq req, CustomUserDetails securityUser) {
+        if (!contentRepository.existsByIdAndDeleteAtIsNull(contentId)) {
+            throw new ContentErrorException(ContentErrorCode.INVALID_CONTENT_ID);
+        }
+
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentErrorException(CommentErrorCode.INVALID_COMMENT_ID));
 
@@ -101,7 +105,12 @@ public class CommentService {
      * @param commentId
      */
     @Transactional
-    public DeleteCommentRes deleteComment(Long commentId, CustomUserDetails securityUser) {
+    public DeleteCommentRes deleteComment(Long contentId, Long commentId, CustomUserDetails securityUser) {
+        System.out.println("repository result = " + contentRepository.existsByIdAndDeleteAtIsNull(contentId));
+        if (!contentRepository.existsByIdAndDeleteAtIsNull(contentId)) {
+            throw new ContentErrorException(ContentErrorCode.INVALID_CONTENT_ID);
+        }
+
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentErrorException(CommentErrorCode.INVALID_COMMENT_ID));
 

--- a/src/main/java/io/oopy/coding/domain/comment/dto/CommentDTO.java
+++ b/src/main/java/io/oopy/coding/domain/comment/dto/CommentDTO.java
@@ -15,14 +15,14 @@ public class CommentDTO {
     private Long id;
     private String commentBody;
     private Long parentId;
-    private LocalDateTime deleteAt;
+    private LocalDateTime deletedAt;
 
     public static CommentDTO fromEntity(Comment comment) {
         return CommentDTO.builder()
                 .id(comment.getId())
                 .commentBody(comment.getCommentBody())
                 .parentId(comment.getParentId())
-                .deleteAt(comment.getDeleteAt())
+                .deletedAt(comment.getDeleteAt())
                 .build();
     }
 }

--- a/src/main/java/io/oopy/coding/domain/comment/dto/GetCommentRes.java
+++ b/src/main/java/io/oopy/coding/domain/comment/dto/GetCommentRes.java
@@ -1,5 +1,7 @@
 package io.oopy.coding.domain.comment.dto;
 
+import io.oopy.coding.domain.comment.entity.Comment;
+import io.oopy.coding.domain.user.entity.User;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -9,23 +11,47 @@ import java.time.LocalDateTime;
 @Builder
 public class GetCommentRes {
 
-    private Comment comment;
-    private User user;
+    private ResComment comment;
+    private ResUser user;
 
     @Builder
     @Getter
-    public static class Comment {
+    public static class ResComment {
         private String body;
         private Long parentId;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private LocalDateTime deletedAt;
+
+        public static ResComment from(Comment comment) {
+            return ResComment.builder()
+                    .body(comment.getCommentBody())
+                    .parentId(comment.getParentId())
+                    .createdAt(comment.getCreatedAt())
+                    .updatedAt(comment.getUpdatedAt())
+                    .deletedAt(comment.getDeleteAt())
+                    .build();
+        }
     }
 
     @Builder
     @Getter
-    public static class User {
+    public static class ResUser {
         private String name;
         private String profileImageUrl;
+
+        public static ResUser from(User user) {
+            return ResUser.builder()
+                    .name(user.getName())
+                    .profileImageUrl(user.getProfileImageUrl())
+                    .build();
+        }
+    }
+
+    public static GetCommentRes fromEntity(Comment comment) {
+        return GetCommentRes.builder()
+                .comment(ResComment.from(comment))
+                .user(ResUser.from(comment.getUser()))
+                .build();
     }
 }

--- a/src/main/java/io/oopy/coding/domain/content/repository/ContentRepository.java
+++ b/src/main/java/io/oopy/coding/domain/content/repository/ContentRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface ContentRepository extends JpaRepository<Content, Long> {
     List<Content> findContentsByUserId(Long userId);
     boolean existsByIdAndUserId(Long id, Long userId);
+
+    boolean existsByIdAndDeleteAtIsNull(Long id);
 }


### PR DESCRIPTION
## 작업 이유
1. [GET] Comment: 응답 시에 유저 데이터를 표시하지 않는 문제 발견
2. [DELETE] Comment:  현재 삭제 된 게시글에 있는 댓글을 삭제 가능 -> 데이터 보존을 위해 수정할 수 없도록 하는 것이 좋을 것이라 생각(추후 협의 사항)
3. [GET] ContentMark: 아무런 mark가 존재하지 않을 시 현재 null로 반환 -> 0으로 반환하는 것이 더 옳아보임
4. [PATCH] ContentMark: Mark타입이 아닌 이상한 문자(ex: dkjnf213) 등을 보냈을 시, Internal Server Error 발생
5. [PATCH] ContentMark: 현재 삭제 된 게시글에 ContentMark 토글 가능 -> 불가능하도록 변경

## 작업 사항
1. commentService.getComments() 로직 반환 값을 CommentDTO 에서 GetCommentRes로 변경
2. url로 들어온 commentId를 바탕으로 게시글이 삭제되었는지 아닌지 확인하는 부분 추가(contentRepository.existsByIdAndDeleteAtIsNull()) -> Update, Delete Comment로직에 모두 추가
3. ContentMarkDto 생성 시 현재 .like(likeCount) -> like(likeCount == null ? 0 : likeCount) 로 변경
4. 반환된 MarkType이 null일 경우 예외 추가
<img width="839" alt="스크린샷 2024-02-23 오후 2 59 42" src="https://github.com/80000Coding/80000Coding-Backend/assets/44596433/77708a89-8d59-47f6-8e7c-ec666c58c8cc">
5. content의 DeleteAt이 존재하는지 여부 판단하는 로직 추가 

## 이슈 연결
